### PR TITLE
fix typo in env var name

### DIFF
--- a/content/docs/configuration/runtime-options.md
+++ b/content/docs/configuration/runtime-options.md
@@ -98,7 +98,7 @@ Specify a password file for SMTP authentication ([see docs](../smtp/)).
 {{< /option >}}
 
 
-{{< option smtp-auth-accept-any MP_SMTP_AUTH_ACCEPT_AN "false"Y >}}
+{{< option smtp-auth-accept-any MP_SMTP_AUTH_ACCEPT_ANY "false"Y >}}
 Accept any SMTP username and password, including none. Use this to basically allow anything.
 {{< /option >}}
 


### PR DESCRIPTION
👋 

This PR fixes a typo on https://mailpit.axllent.org/docs/configuration/runtime-options/ for `MP_SMTP_AUTH_ACCEPT_ANY`