### PR TITLE
Prometheus Metrics Documentation

### DIFF
--- a/content/docs/configuration/prometheus.md
+++ b/content/docs/configuration/prometheus.md
@@ -1,0 +1,76 @@
+---
+title: Prometheus metrics
+description: Monitor Mailpit performance and statistics with Prometheus
+weight: 12
+section: configuration
+keywords: [prometheus, metrics, monitoring, statistics]
+---
+
+Mailpit includes optional Prometheus metrics support to monitor mail server performance and usage statistics. When enabled, Mailpit exposes metrics on a separate HTTP endpoint that can be scraped by Prometheus.
+
+## Enabling Prometheus metrics
+
+Prometheus metrics are disabled by default. To enable them, use either the command line flag or environment variable:
+
+```bash
+# Using command line flag
+mailpit --enable-prometheus
+
+# Using environment variable
+export MP_ENABLE_PROMETHEUS=true
+mailpit
+```
+
+By default, the metrics server will listen on `[::]:9090`. You can customize this using:
+
+```bash
+# Custom listen address
+mailpit --enable-prometheus --prometheus-listen 0.0.0.0:9091
+
+# Using environment variable
+export MP_PROMETHEUS_LISTEN="0.0.0.0:9091"
+```
+
+## Accessing metrics
+
+Once enabled, Prometheus metrics are available at the `/metrics` endpoint:
+
+```
+http://localhost:9090/metrics
+```
+
+## Available metrics
+
+Mailpit exposes the following metrics:
+
+#### Message statistics
+- **`mailpit_messages`** (gauge) - Total number of messages in the database
+- **`mailpit_messages_unread`** (gauge) - Number of unread messages
+- **`mailpit_messages_deleted_total`** (counter) - Total number of messages deleted
+
+#### SMTP statistics
+- **`mailpit_smtp_accepted_total`** (counter) - Total SMTP messages accepted
+- **`mailpit_smtp_rejected_total`** (counter) - Total SMTP messages rejected
+- **`mailpit_smtp_ignored_total`** (counter) - Total SMTP messages ignored (duplicates)
+- **`mailpit_smtp_accepted_size_bytes_total`** (counter) - Total size of accepted SMTP messages in bytes
+
+#### System statistics
+- **`mailpit_database_size_bytes`** (gauge) - Database size in bytes
+- **`mailpit_uptime_seconds`** (gauge) - Mailpit uptime in seconds
+- **`mailpit_memory_usage_bytes`** (gauge) - Current memory usage in bytes
+
+#### Tag statistics
+- **`mailpit_tag_messages`** (gauge) - Number of messages per tag, labeled by tag name
+
+## Prometheus configuration
+
+To configure Prometheus to scrape Mailpit metrics, add the following to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'mailpit'
+    static_configs:
+      - targets: ['localhost:9090']
+    scrape_interval: 30s
+    metrics_path: '/metrics'
+```

--- a/content/docs/configuration/prometheus.md
+++ b/content/docs/configuration/prometheus.md
@@ -6,37 +6,37 @@ section: configuration
 keywords: [prometheus, metrics, monitoring, statistics]
 ---
 
-Mailpit includes optional Prometheus metrics support to monitor mail server performance and usage statistics. When enabled, Mailpit exposes metrics on a separate HTTP endpoint that can be scraped by Prometheus.
+Mailpit includes optional Prometheus metrics support to monitor mail server performance and usage statistics.
 
 ## Enabling Prometheus metrics
 
 Prometheus metrics are disabled by default. To enable them, use either the command line flag or environment variable:
 
+### Integrated mode
+
+Serve metrics on the main web UI port inheriting all configuration such as TLS and authentication at `/metrics`:
+
 ```bash
 # Using command line flag
-mailpit --enable-prometheus
+mailpit --enable-prometheus true
 
-# Using environment variable
+# Using environment variable  
 export MP_ENABLE_PROMETHEUS=true
 mailpit
 ```
 
-By default, the metrics server will listen on `[::]:9090`. You can customize this using:
+
+### Separate server mode
+
+Run a dedicated metrics server on a custom port without TLS or authentication:
 
 ```bash
-# Custom listen address
-mailpit --enable-prometheus --prometheus-listen 0.0.0.0:9091
+# Custom listen address for separate server
+mailpit --enable-prometheus 0.0.0.0:9091
 
 # Using environment variable
-export MP_PROMETHEUS_LISTEN="0.0.0.0:9091"
-```
-
-## Accessing metrics
-
-Once enabled, Prometheus metrics are available at the `/metrics` endpoint:
-
-```
-http://localhost:9090/metrics
+export MP_ENABLE_PROMETHEUS="0.0.0.0:9091"
+mailpit
 ```
 
 ## Available metrics
@@ -66,11 +66,22 @@ Mailpit exposes the following metrics:
 
 To configure Prometheus to scrape Mailpit metrics, add the following to your `prometheus.yml`:
 
+### For integrated mode
 ```yaml
 scrape_configs:
   - job_name: 'mailpit'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost:8025']
+    scrape_interval: 30s
+    metrics_path: '/metrics'
+```
+
+### For separate server mode
+```yaml
+scrape_configs:
+  - job_name: 'mailpit'
+    static_configs:
+      - targets: ['localhost:9091']  # Use your custom port
     scrape_interval: 30s
     metrics_path: '/metrics'
 ```

--- a/content/docs/configuration/runtime-options.md
+++ b/content/docs/configuration/runtime-options.md
@@ -250,13 +250,9 @@ Disable specific auto-tagging. This option takes a comma-separated list of optio
 
 ## Prometheus metrics
 
-{{< option flag="enable-prometheus" env="MP_ENABLE_PROMETHEUS" default="false" added="vXXX" >}}
-Enable Prometheus metrics server. When enabled, metrics are exposed on a separate HTTP endpoint for scraping.
-{{< /option >}}
-
-{{< option flag="prometheus-listen" env="MP_PROMETHEUS_LISTEN" default="[::]:9090" added="vXXX" >}}
-Set the bind interface and port for the Prometheus metrics server.
-The metrics endpoint will be available at `http://[host]:[port]/metrics`.
+{{< option flag="enable-prometheus" env="MP_ENABLE_PROMETHEUS" default="false" added="v1.26.0" >}}
+Enable Prometheus metrics. Set to `true` to serve metrics on the main web UI port at `/metrics`, 
+or specify a bind address (e.g., `0.0.0.0:9090`) to run a separate metrics server.
 {{< /option >}}
 
 

--- a/content/docs/configuration/runtime-options.md
+++ b/content/docs/configuration/runtime-options.md
@@ -248,6 +248,18 @@ Disable specific auto-tagging. This option takes a comma-separated list of optio
 {{< /option >}}
 
 
+## Prometheus metrics
+
+{{< option flag="enable-prometheus" env="MP_ENABLE_PROMETHEUS" default="false" added="vXXX" >}}
+Enable Prometheus metrics server. When enabled, metrics are exposed on a separate HTTP endpoint for scraping.
+{{< /option >}}
+
+{{< option flag="prometheus-listen" env="MP_PROMETHEUS_LISTEN" default="[::]:9090" added="vXXX" >}}
+Set the bind interface and port for the Prometheus metrics server.
+The metrics endpoint will be available at `http://[host]:[port]/metrics`.
+{{< /option >}}
+
+
 ## Webhook
 
 {{< option flag="webhook-url" env="MP_WEBHOOK_URL" >}}


### PR DESCRIPTION
This PR adds documentation for the  Prometheus metrics feature.
Added in axllent/mailpit#505
### New Prometheus Metrics Page
- **File**: `content/docs/configuration/prometheus.md`
- Complete guide for enabling and configuring Prometheus metrics
- Detailed list of all available metrics with descriptions

### Updated Runtime Options
- Added new "Prometheus metrics" section with configuration options:
- `--enable-prometheus` / `MP_ENABLE_PROMETHEUS`
