### PR TITLE
Add docs: username auto tagging & disabling version checking

### DIFF
--- a/content/docs/configuration/runtime-options.md
+++ b/content/docs/configuration/runtime-options.md
@@ -255,6 +255,10 @@ Enforces TitleCasing for all newly-created tags ([see docs](../../usage/tagging/
 Disable specific auto-tagging. This option takes a comma-separated list of options ([see docs](../../usage/tagging/#disable-auto-tagging)).
 {{< /option >}}
 
+{{< option flag="tags-username" env="MP_TAGS_USERNAME" default="false" added="vNEXT" >}}
+Automatically tag messages with the authenticated username (SMTP or HTTP). Useful for multi-user environments to easily filter and identify messages by user. When enabled, a tag matching the username will be added to each message sent by an authenticated user.
+{{< /option >}}
+
 
 ## Prometheus metrics
 

--- a/content/docs/configuration/runtime-options.md
+++ b/content/docs/configuration/runtime-options.md
@@ -21,6 +21,10 @@ WAL (enabled by default) provides better performance, however is not compatible 
 Set this option if you intend on using persistent storage on a network volume.
 {{< /option >}}
 
+{{< option flag="disable-version-check" env="MP_DISABLE_VERSION_CHECK" added="vNEXT" default="false" >}}
+Disable Mailpit's automatic version checking. When enabled, Mailpit will not contact GitHub to check for new releases.
+{{< /option >}}
+
 {{< option flag="compression" env="MP_COMPRESSION" added="v1.23.0" default="1" >}}
 Compression level to store raw messages in the database (0-3) ([see docs](../compression/).)
 {{< /option >}}

--- a/content/docs/usage/tagging.md
+++ b/content/docs/usage/tagging.md
@@ -30,7 +30,12 @@ To enable TitleCasing for new tags, you can set the `--tags-title-case` or set t
 
 ## Automatically tag messages
 
-Messages can be automatically tagged using any combination of three methods: setting an `X-Tags` email header, using "plus addressing", and via word/phrase matches (filtering) when receiving emails.
+Messages can be automatically tagged using any combination of the following methods:
+
+- Setting an `X-Tags` email header
+- Using "plus addressing"
+- Using word/phrase matches (filtering)
+- Username auto-tagging
 
 
 ### Disable auto-tagging
@@ -102,3 +107,11 @@ The `--tag "<syntax>"` (@env `MP_TAG="<syntax>"`) accepts a space-separated stri
 In the above example all messages containing `user@example.com` are tagged with `user`, all messages **from** `user2@example.com` are tagged with `user2`, and all messages containing `X-Antivirus: ` are tagged with `Scanned with antivirus`.
 
 Tags are split by a comma, so multiple tags can be assigned for a match using the following format: `"Tag 1, Tag2"="this is the match"`.
+
+### Username auto-tagging
+
+Mailpit can automatically tag messages with the authenticated username (SMTP or HTTP) when the `--tags-username` flag or `MP_TAGS_USERNAME` environment variable is enabled. This is especially useful in multi-user environments, allowing you to easily filter and identify messages by user.
+
+- When enabled, a tag matching the username will be added to each message sent by an authenticated user.
+- Username tags appear alongside other tags in the web UI and can be used in search filters (e.g., `tag:"alice"`).
+- This feature works for both SMTP and HTTP authenticated users.


### PR DESCRIPTION
## Documentation for username auto tagging & disabling version checking feature
Goes with the changes proposed in resolves axllent/mailpit#524 & axllent/mailpit#521

### Changes Made

- **Runtime options**: 
  - Added new `--disable-version-check` flag and `MP_DISABLE_VERSION_CHECK` environment variable
  - Added new `--tags-username` flag and `MP_TAGS_USERNAME` environment variable
- **Tagging usage docs**: 
  - Documented username auto-tagging, including usage and filtering

### New Documentation Covers

- How to disable Mailpit’s automatic version checking via flag or environment variable
- How to enable username auto-tagging for SMTP/HTTP authenticated users

If the version check disable is not wanted yet feel free to revert the last commit.

Version has been set to `vNEXT` for now
