### PR TITLE
Add search filter for messages by authenticated SMTP username

### DIFF
--- a/content/docs/usage/mailboxes.md
+++ b/content/docs/usage/mailboxes.md
@@ -1,0 +1,61 @@
+---
+title: Separate mailboxes
+description: View captured mail grouped by the authenticated SMTP username, as a separate switchable mailbox per user
+section: usage
+keywords: [mailbox, mailboxes, username, multi-user, separate, inbox, smtp auth, switch]
+weight: 3
+---
+
+Mailpit stores all received mail in a single database, but when [SMTP authentication](../../configuration/smtp/#adding-smtp-authentication) is enabled it records the authenticated username on every message. Each distinct username then appears as its own **mailbox** in the web UI, allowing several services to share one Mailpit instance while viewing each one's mail separately.
+
+This requires no additional configuration beyond enabling SMTP authentication — the mailbox switcher appears automatically once authenticated mail has been received.
+
+## Setup
+
+### 1. Enable SMTP authentication with a username per service
+
+Configure [SMTP authentication](../../configuration/smtp/#adding-smtp-authentication) using a [password file](../../configuration/passwords/), giving each service its own username, for example:
+
+```text
+service-a:$2y$...bcrypt-hash...
+service-b:$2y$...bcrypt-hash...
+```
+
+Start Mailpit with the credentials:
+
+```shell
+mailpit --smtp-auth-file ./smtp-auth.txt
+```
+
+{{< tip "warning" >}}
+Enabling SMTP authentication means **all** senders must authenticate — unauthenticated mail is rejected. For testing over an unencrypted connection you can add the `--smtp-auth-allow-insecure` flag. See [Adding SMTP authentication](../../configuration/smtp/#adding-smtp-authentication) for the full details.
+{{< /tip >}}
+
+### 2. Point each service at its own username
+
+Configure each application to authenticate with its own credentials, for example:
+
+```text
+MAIL_HOST=<mailpit-host>
+MAIL_PORT=1025
+MAIL_USERNAME=service-a
+MAIL_PASSWORD=<service-a password>
+```
+
+### 3. Switch between mailboxes
+
+Once each service has sent mail, use the **Mailbox** dropdown in the web UI sidebar to switch between `All mail` and each username. Selecting a mailbox shows only the messages sent by that authenticated user.
+
+The selected mailbox acts as a persistent scope: [tags](../tagging/) and [searches](../search-filters/) apply *within* the current mailbox rather than across all mail. You can also filter directly using the [`username:` search filter](../search-filters/) (e.g. `username:service-a`), or open a mailbox by URL at `/mailbox/service-a`.
+
+## Trusted vs. untrusted usernames
+
+When authentication is configured with a [password file](../../configuration/passwords/), the supplied password is verified against the stored hash, so the mailbox label reflects a sender that proved it owns those credentials.
+
+{{< option flag="smtp-auth-accept-any" env="MP_SMTP_AUTH_ACCEPT_ANY" default="false" >}}
+Accept any SMTP username and password (or none). Any username is accepted **without a password check**, so mail is filed under whatever username the sender claims, but the mailbox label cannot be trusted. Mail sent with no authentication at all has no username and only appears under `All mail`.
+{{< /option >}}
+
+## Relation to username tagging
+
+This feature is independent of [username auto-tagging](../tagging/#username-auto-tagging) (`--tags-username`). The mailbox switcher reads the authenticated username stored on each message directly, so you do **not** need to enable `--tags-username` to use it. Enable username tagging as well only if you also want each message labelled with a clickable username tag.

--- a/content/docs/usage/search-filters.md
+++ b/content/docs/usage/search-filters.md
@@ -20,6 +20,7 @@ The Mailpit search has a number of features, including filtering by `To`, `From`
 -   `subject:"john doe"` - has "john doe" in the subject line
 -   `message-id:12345.678910.JavaMail.j2ee@localhost` - search by Message-Id
 -   `tag:host-1` - messages tagged with `host-1`
+-   `username:service-a` - messages sent by the authenticated SMTP/Send API username `service-a` (exact match), used by the [separate mailboxes](../mailboxes/) feature
 
 ## Combining filters
 


### PR DESCRIPTION
## What this adds

Documentation for the **separate mailboxes** feature: when SMTP authentication is
enabled, Mailpit records the authenticated username on each message, so each distinct
username can be viewed as its own switchable mailbox in the web UI.

- **New page** — `content/docs/usage/mailboxes.md` ("Separate mailboxes"), covering:
  - enabling SMTP auth with a username per service (links to the existing
    [SMTP authentication](https://mailpit.axllent.org/docs/configuration/smtp/#adding-smtp-authentication)
    and [password file](https://mailpit.axllent.org/docs/configuration/passwords/) docs
    rather than duplicating them)
  - switching mailboxes via the sidebar dropdown, the `username:` search filter, and the
    `/mailbox/<name>` URL
  - trusted vs. untrusted usernames (`--smtp-auth-accept-any`)
  - its relationship to `--tags-username` auto-tagging
- **Updated** `content/docs/usage/search-filters.md` — adds the `username:<name>` filter
  to the examples list.

## Related

Documents the feature added in [axllent/mailpit#718](https://github.com/axllent/mailpit/pull/718). 
That code PR should land
first, since this describes behaviour not yet in a released Mailpit build.

## Notes

- Built and previewed locally with `hugo server` (Hugo v0.164.0 extended): the new page
  renders correctly, appears under **Usage → Separate mailboxes**, and all cross-links
  and anchors resolve.
- Uses the existing `tip` and `option` shortcodes — no new dependencies or config.